### PR TITLE
添加数据位9的支持

### DIFF
--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -693,7 +693,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     tios.c_cflag |= (CREAD | CLOCAL);
     /* CSIZE, HUPCL, CRTSCTS (hardware flow control) */
 
-    /* Set data bits (5, 6, 7, 8 bits)
+    /* Set data bits (5, 6, 7, 8, 9, bits)
        CSIZE        Bit mask for data bits
     */
     tios.c_cflag &= ~CSIZE;
@@ -706,6 +706,9 @@ static int _modbus_rtu_connect(modbus_t *ctx)
         break;
     case 7:
         tios.c_cflag |= CS7;
+        break;
+    case 9:
+        tios.c_cflag |= CS9;
         break;
     case 8:
     default:


### PR DESCRIPTION
主要是针对类似STM32这种有9bit数据长度的MCU支持。
具体如下： https://club.rt-thread.org/ask/article/3238.html